### PR TITLE
instarepo automatic PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Maven plugin that can create Bitbucket tags and ensures the version in pom.xml
 is not conflicting with an existing tag.
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.ngeor/yak4j-bitbucket-maven-plugin.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.github.ngeor%22%20AND%20a:%22yak4j-bitbucket-maven-plugin%22)
+[![Java CI with Maven](https://github.com/ngeor/yak4j-bitbucket-maven-plugin/actions/workflows/maven.yml/badge.svg)](https://github.com/ngeor/yak4j-bitbucket-maven-plugin/actions/workflows/maven.yml)
+[![javadoc](https://javadoc.io/badge2/com.github.ngeor/yak4j-bitbucket-maven-plugin/javadoc.svg)](https://javadoc.io/doc/com.github.ngeor/yak4j-bitbucket-maven-plugin)
 
 ## Goals
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <!--
     dependencies for maven plugins
     -->
-    <maven-core.version>3.8.3</maven-core.version>
+    <maven-core.version>3.8.4</maven-core.version>
     <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
     <!--
     jacoco thresholds


### PR DESCRIPTION
The following fixes have been applied:
- Updated pom properties
  Updated ${maven-core.version} from 3.8.3 to 3.8.4
  Property ${maven-plugin-plugin.version}: Leaving unchanged as 3.6.0
  Property ${maven-invoker-plugin.version}: Leaving unchanged as 3.2.1
- Updated Maven badges in README.md
